### PR TITLE
additional settings in gui

### DIFF
--- a/uisettings_controller.cpp
+++ b/uisettings_controller.cpp
@@ -36,6 +36,10 @@ void UISettingsController::Load(IPropertyProvider* p_pValues)
 	p_pValues->GetINT32("x264_bitrate", m_BitRate);
 	p_pValues->GetString("x264_enc_markers", m_MarkerColor);
 	p_pValues->GetINT32("x264_level", m_Level);
+	p_pValues->GetINT32("x264_kf_max", m_KFMax);
+	p_pValues->GetINT32("x264_kf_min", m_KFMin);
+	p_pValues->GetINT32("x264_bf", m_BF);
+	p_pValues->GetINT32("x264_scene_detection", m_SceneDetection);
 }
 
 StatusCode UISettingsController::Render(HostListRef* p_pSettingsList)
@@ -77,10 +81,14 @@ void UISettingsController::InitDefaults()
 	m_EncPreset = 4;
 	m_Tune = 0;
 	m_NumPasses = 1;
-	m_Level = 0;
+	m_Level = 0; 
 	m_QualityMode = X264_RC_CRF;
 	m_QP = 23;
 	m_BitRate = 8000;
+	m_KFMax = 250;
+	m_KFMin = 25;
+	m_BF = 3;
+	m_SceneDetection = 40;
 }
 
 StatusCode UISettingsController::RenderGeneral(HostListRef* p_pSettingsList)
@@ -255,6 +263,86 @@ StatusCode UISettingsController::RenderQuality(HostListRef* p_pSettingsList)
 		item.SetHidden((m_QualityMode == X264_RC_ABR) || (m_NumPasses > 1));
 		if (!item.IsSuccess() || !p_pSettingsList->Append(&item)) {
 			g_Log(logLevelError, "X264 Plugin :: Failed to populate qp slider UI entry");
+			return errFail;
+		}
+	}
+
+	{
+		HostUIConfigEntryRef item("x264_separator");
+		item.MakeSeparator();
+		if (!item.IsSuccess() || !p_pSettingsList->Append(&item)) {
+			g_Log(logLevelError, "X264 Plugin :: Failed to add a separator entry");
+			return errFail;
+		}
+	}
+
+	{
+		HostUIConfigEntryRef item("x264_kf_max");
+		const char* pLabel = NULL;
+		if (m_KFMax == 250) {
+			pLabel = "(default)";
+		} else {
+			pLabel = " ";
+		}
+		item.MakeSlider("Keyframes Max", pLabel, m_KFMax, 1, 300, 250);
+		item.SetTriggersUpdate(true);
+		if (!item.IsSuccess() || !p_pSettingsList->Append(&item)) {
+			g_Log(logLevelError, "X264 Plugin :: Failed to populate kf max slider UI entry");
+			return errFail;
+		}
+	}
+
+	{
+		if (m_KFMin > m_KFMax)
+		m_KFMin = m_KFMax;
+		HostUIConfigEntryRef item("x264_kf_min");
+		const char* pLabel = NULL;
+		if (m_KFMin == 25) {
+			pLabel = "(default)";
+		} else {
+			pLabel = " ";
+		}
+		item.MakeSlider("Keyframes Min", pLabel, m_KFMin, 1, 300, 25);
+		item.SetTriggersUpdate(true);
+		if (!item.IsSuccess() || !p_pSettingsList->Append(&item)) {
+			g_Log(logLevelError, "X264 Plugin :: Failed to populate kf min slider UI entry");
+			return errFail;
+		}
+	}
+
+	{
+		if (m_BF > m_KFMax - 2) {
+    		m_BF = std::max(0, m_KFMax - 2);
+		}
+		HostUIConfigEntryRef item("x264_bf");
+		const char* pLabel = NULL;
+		if (m_BF == 3) {
+			pLabel = "(default)";
+		} else {
+			pLabel = " ";
+		}
+		item.MakeSlider("B-Frames", pLabel, m_BF, 0, 5, 3);
+		item.SetTriggersUpdate(true);
+		if (!item.IsSuccess() || !p_pSettingsList->Append(&item)) {
+			g_Log(logLevelError, "X264 Plugin :: Failed to populate bf slider UI entry");
+			return errFail;
+		}
+	}
+
+	{
+		HostUIConfigEntryRef item("x264_scene_detection");
+		const char* pLabel = NULL;
+		if (m_SceneDetection == 40) {
+			pLabel = "(default)";
+		} else if (m_SceneDetection == 0) {
+			pLabel = "(OFF)";
+		} else {
+			pLabel = " ";
+		}
+		item.MakeSlider("Scenecut Threshold", pLabel, m_SceneDetection, 0, 100, 40);
+		item.SetTriggersUpdate(true);
+		if (!item.IsSuccess() || !p_pSettingsList->Append(&item)) {
+			g_Log(logLevelError, "X264 Plugin :: Failed to populate scene detection slider UI entry");
 			return errFail;
 		}
 	}

--- a/uisettings_controller.h
+++ b/uisettings_controller.h
@@ -64,6 +64,26 @@ namespace IOPlugin {
 			return m_BitRate;
 		}
 
+		int32_t GetKFMax() const
+		{
+			return std::max<int>(0, m_KFMax);
+		}
+
+		int32_t GetKFMin() const
+		{
+			return std::max<int>(0, m_KFMin);
+		}
+
+		int32_t GetBF() const
+		{
+			return std::max<int>(0, m_BF);
+		}
+
+		int32_t GetSceneDetection() const
+		{
+			return std::max<int>(0, m_SceneDetection);
+		}
+
 		const std::string& GetMarkerColor() const
 		{
 			return m_MarkerColor;
@@ -83,6 +103,10 @@ namespace IOPlugin {
 		int32_t m_QP;
 		int32_t m_BitRate;
 		int32_t m_Level;
+		int32_t m_KFMax;
+		int32_t m_KFMin;
+		int32_t m_BF;
+		int32_t m_SceneDetection;
 	};
 
 }

--- a/x264_encoder.cpp
+++ b/x264_encoder.cpp
@@ -286,11 +286,26 @@ void X264Encoder::SetupContext(bool p_IsFinalPass)
 		}
 	}
 
+	const int keyframeIntervalMax = m_pSettings->GetKFMax();
+	param.i_keyint_max = keyframeIntervalMax;
+	g_Log(logLevelInfo, "X264 Plugin :: SetupContext :: keyframe interval max = %d", keyframeIntervalMax);
+
+	const int keyframeIntervalMin = m_pSettings->GetKFMin();
+	param.i_keyint_min = keyframeIntervalMin;
+	g_Log(logLevelInfo, "X264 Plugin :: SetupContext :: keyframe interval max = %d", keyframeIntervalMin);
+
+	const int bframeInterval = m_pSettings->GetBF();
+	param.i_bframe = bframeInterval;
+	g_Log(logLevelInfo, "X264 Plugin :: SetupContext :: b-frame interval = %d", bframeInterval);
+
+	const int SceneDetection = m_pSettings->GetSceneDetection();
+	param.i_scenecut_threshold = SceneDetection;
+	g_Log(logLevelInfo, "X264 Plugin :: SetupContext :: scene detection = %d", SceneDetection);
+
 	m_BFrames = param.i_bframe;
+	g_Log(logLevelInfo, "X264 Plugin :: Final settings :: keyint_min = %d, keyint_max = %d, scenecut_threshold = %d", param.i_keyint_min, param.i_keyint_max, param.i_scenecut_threshold);
 
 	x264_t* pContext = x264_encoder_open(&param);
-
-	g_Log(logLevelInfo, "X264 Plugin :: SetupContext :: pContext = %d", pContext);
 
 	if (pContext != NULL) {
 		m_pContext.reset(pContext);


### PR DESCRIPTION
Added settings in Davinci Export:

- Maximum I-Frame (default to 250 as per x264 default)
- Minimum I-Frame (default to 25 as per x264 default)
- B-Frame (default to 3 as per x264 default)
- Scene Detection (default to 40 as per x264 default)

Set relation rules to max/min/b-frames